### PR TITLE
Make a first pass at a dataplane role.

### DIFF
--- a/ansible-universal/roles/all/tasks/main.yml
+++ b/ansible-universal/roles/all/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+
+- name: Add IPv4 address for control-plane hosts
+  lineinfile:
+    dest: /etc/hosts
+    regexp: '.*{{ item }}$'
+    line: "{{ hostvars[item].ansible_facts.eth0.ipv4.address }} control-plane # inventory host '{{ item }}'"
+    state: present
+  when: hostvars[item].ansible_facts.eth0.ipv4.address is defined
+  with_items: "{{ groups.controlplane }}"

--- a/ansible-universal/roles/control-plane/templates/kuma.conf
+++ b/ansible-universal/roles/control-plane/templates/kuma.conf
@@ -2,3 +2,12 @@
 general:
   workDir: {{ kuma_statedir }}
 
+apiServer:
+  readOnly: false
+  http:
+    enabled: true
+    interface: 0.0.0.0
+    port: 5681
+
+dpServer:
+  port: 5678

--- a/ansible-universal/roles/data-plane/handlers/main.yml
+++ b/ansible-universal/roles/data-plane/handlers/main.yml
@@ -1,0 +1,14 @@
+---
+
+- name: restart kuma-dp service
+  listen: restart kuma services
+  ansible.builtin.systemd:
+    name: kuma-dp
+    state: restarted
+
+- name: reload kuma-dp service
+  ansible.builtin.systemd:
+    name: kuma-dp
+    state: restarted
+    daemon_reload: yes
+

--- a/ansible-universal/roles/data-plane/tasks/main.yml
+++ b/ansible-universal/roles/data-plane/tasks/main.yml
@@ -1,0 +1,62 @@
+---
+
+- name: Install podman
+  ansible.builtin.package:
+    name: podman
+    state: present
+
+- name: Install envoy wrapper
+  ansible.builtin.template:
+    src: envoy
+    dest: "{{ kuma_bindir }}/envoy"
+    mode: "0755"
+
+- name: Create persistent state directory
+  ansible.builtin.file:
+    path: "{{ kuma_statedir }}"
+    state: directory
+    owner: kuma
+    group: kuma
+    mode: "0700"
+
+- name: Add kumactl control plane
+  become: yes
+  become_user: kuma
+  ansible.builtin.command:
+    cmd: "{{ kuma_bindir }}/kumactl config control-planes add --overwrite --name kuma --address http://control-plane:5681"
+
+- name: Set current kumactcl control plane
+  become: yes
+  become_user: kuma
+  ansible.builtin.command:
+    cmd: "{{ kuma_bindir }}/kumactl config control-planes switch --name kuma"
+
+- name: Create dataplanes directory
+  ansible.builtin.file:
+    path: "{{ kuma_confdir }}/dataplanes"
+    state: directory
+    mode: "0755"
+
+- name: Create sysconfig directory
+  ansible.builtin.file:
+    path: /etc/sysconfig
+    state: directory
+    mode: "0755"
+
+- name: Install kuma-dp sysconfig
+  notify: restart kuma-dp service
+  ansible.builtin.template:
+    src: kuma-dp.sysconfig
+    dest: /etc/sysconfig/kuma-dp
+
+- name: Install dataplane sysconfig
+  notify: restart kuma-dp service
+  ansible.builtin.template:
+    src: dataplane.conf
+    dest: "{{ kuma_confdir }}/dataplanes/{{ service_name }}.conf"
+
+- name: Install kuma-dp service
+  notify: reload kuma-dp service
+  ansible.builtin.template:
+    src: kuma-dp.service
+    dest: /etc/systemd/system/kuma-dp.service

--- a/ansible-universal/roles/data-plane/templates/dataplane.conf
+++ b/ansible-universal/roles/data-plane/templates/dataplane.conf
@@ -1,0 +1,12 @@
+# {{ ansible_managed }}.
+
+type: Dataplane
+mesh: default
+name: {{ ansible_facts['nodename'] | replace('.', '-') }}
+networking:
+  address: 127.0.0.1
+  inbound:
+  - port: {{ service_port }}
+    servicePort: {{ workload_port }}
+    tags:
+      kuma.io/service: {{ service_name }}

--- a/ansible-universal/roles/data-plane/templates/envoy
+++ b/ansible-universal/roles/data-plane/templates/envoy
@@ -1,0 +1,11 @@
+#! /usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+readonly DOCKER=${DOCKER:-podman}
+readonly ENVOY=${ENVOY:-docker.io/envoyproxy/envoy-distroless:v1.19.1}
+
+exec $DOCKER run --network host $ENVOY "$@"
+

--- a/ansible-universal/roles/data-plane/templates/kuma-dp.service
+++ b/ansible-universal/roles/data-plane/templates/kuma-dp.service
@@ -1,0 +1,38 @@
+# {{ ansible_managed }}.
+
+[Unit]
+Description=Kuma Data Plane in Universal mode
+After=network.target
+Documentation=https://kuma.io
+
+[Service]
+EnvironmentFile=-/etc/sysconfig/kuma-cp
+
+ExecStartPre={{ kuma_bindir }}/kumactl generate dataplane-token \
+    --proxy-type dataplane \
+    --name "{{ ansible_facts['nodename'] | replace('.', '-') }}" \
+    > "{{ kuma_statedir }}/{{ ansible_facts['nodename'] | replace('.', '-') }}".dp
+
+ExecStart={{ kuma_bindir }}/kuma-dp run \
+    --proxy-type dataplane \
+    --cp-address https://control-plane:5678 \
+    --dataplane-token-file "{{ kuma_statedir }}/{{ ansible_facts['nodename'] | replace('.', '-') }}".dp \
+    --dataplane-file "{{ kuma_confdir }}/dataplanes/{{ service_name }}.conf" \
+    --config-dir "{{ kuma_statedir }}/kuma-dp/{{ service_name }}" \
+    --dns-server-config-dir "{{ kuma_statedir }}/kuma-dp/{{ service_name }}" \
+    --dns-coredns-path "{{ kuma_bindir }}/coredns" \
+    --binary-path "{{ kuma_bindir }}/envoy"
+
+Restart=always
+RestartSec=1s
+
+StartLimitIntervalSec=0
+StartLimitBurst=0
+
+User=kuma
+
+LimitNOFILE=1048576
+
+[Install]
+WantedBy=multi-user.target
+

--- a/ansible-universal/roles/data-plane/templates/kuma-dp.sysconfig
+++ b/ansible-universal/roles/data-plane/templates/kuma-dp.sysconfig
@@ -1,0 +1,2 @@
+# {{ ansible_managed }}.
+# kuma-dp environment variables.

--- a/ansible-universal/roles/data-plane/vars/main.yml
+++ b/ansible-universal/roles/data-plane/vars/main.yml
@@ -1,0 +1,5 @@
+---
+
+service_name:
+service_port:
+workload_port:

--- a/ansible-universal/roles/install-kuma/tasks/main.yml
+++ b/ansible-universal/roles/install-kuma/tasks/main.yml
@@ -8,7 +8,7 @@
   ansible.builtin.user:
     name: kuma
     comment: kuma role user
-    create_home: no
+    create_home: yes # Some tools (e.g. podman) require a home directory.
     group: kuma
     password: "*"
 

--- a/ansible-universal/site.yml
+++ b/ansible-universal/site.yml
@@ -1,5 +1,10 @@
 ---
 
+- hosts: all
+  roles:
+  - role: all
+    become: yes
+
 - hosts: controlplane
   roles:
   - role: install-kuma
@@ -13,3 +18,9 @@
     become: yes
   - role: echo-server
     become: yes
+    listen_port: 8080
+  - role: data-plane
+    become: yes
+    service_name: echo
+    service_port: 20000
+    workload_port: 8080


### PR DESCRIPTION
The "data-plane" role is intended to configure a node as a Kuma dataplane
running a single service. This is more restrictive that we really want,
which is to be able to run services anywhere, so maybe at some point
this role should simply be included in the corresponding service role.

Dataplanes are not yet able to boostrap since they don't have a way to
authenticate to the control plane to get a dataplane token.

Added an "all" role to configure a generic control-plane DNS name for
all the nodes. This makes the kuma-cp instance reachable.

Various ports and such are still hard-coded across roles, and TLS is
still not enabled for the kuma-cp API server.

Signed-off-by: James Peach <james.peach@konghq.com>