### PR TITLE
Move Envoy install to the main installation role.

### DIFF
--- a/ansible-universal/roles/data-plane/tasks/main.yml
+++ b/ansible-universal/roles/data-plane/tasks/main.yml
@@ -1,16 +1,5 @@
 ---
 
-- name: Install podman
-  ansible.builtin.package:
-    name: podman
-    state: present
-
-- name: Install envoy wrapper
-  ansible.builtin.template:
-    src: envoy
-    dest: "{{ kuma_bindir }}/envoy"
-    mode: "0755"
-
 - name: Create persistent state directory
   ansible.builtin.file:
     path: "{{ kuma_statedir }}"

--- a/ansible-universal/roles/install-kuma/tasks/envoy.yaml
+++ b/ansible-universal/roles/install-kuma/tasks/envoy.yaml
@@ -1,0 +1,12 @@
+---
+
+- name: Install podman
+  ansible.builtin.package:
+    name: podman
+    state: present
+
+- name: Install envoy wrapper
+  ansible.builtin.template:
+    src: envoy.sh
+    dest: "{{ kuma_bindir }}/envoy"
+    mode: "0755"

--- a/ansible-universal/roles/install-kuma/tasks/kuma-binaries.yaml
+++ b/ansible-universal/roles/install-kuma/tasks/kuma-binaries.yaml
@@ -1,0 +1,56 @@
+---
+
+- name: Create installation directory
+  ansible.builtin.file:
+    path: "{{ kuma_bindir }}"
+    state: directory
+    mode: "0755"
+
+- name: Copy kumactl
+  ansible.builtin.copy:
+    src: "{{ builddir }}/artifacts-linux-amd64/kumactl/kumactl"
+    dest: "{{ kuma_bindir }}/kumactl"
+    mode: "0755"
+  notify:
+  - restart kuma services
+
+- name: Copy kuma-cp
+  ansible.builtin.copy:
+    src: "{{ builddir }}/artifacts-linux-amd64/kuma-cp/kuma-cp"
+    dest: "{{ kuma_bindir }}/kuma-cp"
+    mode: "0755"
+  notify:
+  - restart kuma services
+
+- name: Copy kuma-dp
+  ansible.builtin.copy:
+    src: "{{ builddir }}/artifacts-linux-amd64/kuma-dp/kuma-dp"
+    dest: "{{ kuma_bindir }}/kuma-dp"
+    mode: "0755"
+  notify:
+  - restart kuma services
+
+- name: Copy coredns
+  ansible.builtin.copy:
+    src: "{{ builddir }}/artifacts-linux-amd64/coredns/coredns"
+    dest: "{{ kuma_bindir }}/coredns"
+    mode: "0755"
+  notify:
+  - restart kuma services
+
+- name: Copy test-server
+  ansible.builtin.copy:
+    src: "{{ builddir }}/artifacts-linux-amd64/test-server/test-server"
+    dest: "{{ kuma_bindir }}/test-server"
+    mode: "0755"
+  notify:
+  - restart kuma services
+
+- name: Copy kuma-prometheus-sd
+  ansible.builtin.copy:
+    src: "{{ builddir }}/artifacts-linux-amd64/kuma-prometheus-sd/kuma-prometheus-sd"
+    dest: "{{ kuma_bindir }}/kuma-prometheus-sd"
+    mode: "0755"
+  notify:
+  - restart kuma services
+

--- a/ansible-universal/roles/install-kuma/tasks/kumactl.yaml
+++ b/ansible-universal/roles/install-kuma/tasks/kumactl.yaml
@@ -1,0 +1,24 @@
+--- 
+
+- name: Add Kuma to user $PATH
+  ansible.builtin.template:
+    src: kuma.profile
+    dest: /etc/profile.d/kuma.sh
+
+- name: Generate Kumactl bash completion
+  register: kumactl_completion_bash
+  ansible.builtin.command:
+    argv:
+    - "{{ kuma_bindir }}/kumactl"
+    - completion
+    - bash
+
+- name: Install Kumactl bash completion
+  ansible.builtin.copy:
+    content: "{{ kumactl_completion_bash.stdout }}"
+    dest: /etc/bash_completion.d/kumactl.sh
+
+- name: Install bash-completion package
+  ansible.builtin.package:
+    name: bash-completion
+    state: present

--- a/ansible-universal/roles/install-kuma/tasks/main.yml
+++ b/ansible-universal/roles/install-kuma/tasks/main.yml
@@ -12,79 +12,11 @@
     group: kuma
     password: "*"
 
-- name: Create installation directory
-  ansible.builtin.file:
-    path: "{{ kuma_bindir }}"
-    state: directory
-    mode: "0755"
+- name: Install Kuma binaries
+  import_tasks: kuma-binaries.yaml
 
-- name: Copy kumactl
-  ansible.builtin.copy:
-    src: "{{ builddir }}/artifacts-linux-amd64/kumactl/kumactl"
-    dest: "{{ kuma_bindir }}/kumactl"
-    mode: "0755"
-  notify:
-  - restart kuma services
+- name: Configure kumactl
+  import_tasks: kuma-binaries.yaml
 
-- name: Copy kuma-cp
-  ansible.builtin.copy:
-    src: "{{ builddir }}/artifacts-linux-amd64/kuma-cp/kuma-cp"
-    dest: "{{ kuma_bindir }}/kuma-cp"
-    mode: "0755"
-  notify:
-  - restart kuma services
-
-- name: Copy kuma-dp
-  ansible.builtin.copy:
-    src: "{{ builddir }}/artifacts-linux-amd64/kuma-dp/kuma-dp"
-    dest: "{{ kuma_bindir }}/kuma-dp"
-    mode: "0755"
-  notify:
-  - restart kuma services
-
-- name: Copy coredns
-  ansible.builtin.copy:
-    src: "{{ builddir }}/artifacts-linux-amd64/coredns/coredns"
-    dest: "{{ kuma_bindir }}/coredns"
-    mode: "0755"
-  notify:
-  - restart kuma services
-
-- name: Copy test-server
-  ansible.builtin.copy:
-    src: "{{ builddir }}/artifacts-linux-amd64/test-server/test-server"
-    dest: "{{ kuma_bindir }}/test-server"
-    mode: "0755"
-  notify:
-  - restart kuma services
-
-- name: Copy kuma-prometheus-sd
-  ansible.builtin.copy:
-    src: "{{ builddir }}/artifacts-linux-amd64/kuma-prometheus-sd/kuma-prometheus-sd"
-    dest: "{{ kuma_bindir }}/kuma-prometheus-sd"
-    mode: "0755"
-  notify:
-  - restart kuma services
-
-- name: Add Kuma to user $PATH
-  ansible.builtin.template:
-    src: kuma.profile
-    dest: /etc/profile.d/kuma.sh
-
-- name: Generate Kumactl bash completion
-  register: kumactl_completion_bash
-  ansible.builtin.command:
-    argv:
-    - "{{ kuma_bindir }}/kumactl"
-    - completion
-    - bash
-
-- name: Install Kumactl bash completion
-  ansible.builtin.copy:
-    content: "{{ kumactl_completion_bash.stdout }}"
-    dest: /etc/bash_completion.d/kumactl.sh
-
-- name: Install bash-completion package
-  ansible.builtin.package:
-    name: bash-completion
-    state: present
+- name: Install Envoy binaries
+  import_tasks: envoy.yaml

--- a/ansible-universal/roles/install-kuma/templates/envoy.sh
+++ b/ansible-universal/roles/install-kuma/templates/envoy.sh
@@ -5,7 +5,7 @@ set -o pipefail
 set -o nounset
 
 readonly DOCKER=${DOCKER:-podman}
-readonly ENVOY=${ENVOY:-docker.io/envoyproxy/envoy-distroless:v1.19.1}
+readonly ENVOY=${ENVOY:-{{envoy.repository}}:{{envoy.version}}}
 
 exec $DOCKER run --network host $ENVOY "$@"
 

--- a/ansible-universal/roles/install-kuma/vars/main.yml
+++ b/ansible-universal/roles/install-kuma/vars/main.yml
@@ -1,3 +1,7 @@
 ---
 
 builddir: /home/jpeach/upstream/konghq/kuma/build
+
+envoy:
+  repository: docker.io/envoyproxy/envoy-distroless
+  version: v1.20.0


### PR DESCRIPTION
As a general principle, we can say that Envoy is bundled with Kuma,
so install the Envoy wrappers in the same role as Kuma. This means
that any host with the "install-kuma" role ends up with everything
it needs to actually run a Kuma cluster component.

Signed-off-by: James Peach <james.peach@konghq.com>