### PR TITLE
Copy files using rsync.

### DIFF
--- a/ansible-universal/roles/install-kuma/tasks/kuma-binaries.yaml
+++ b/ansible-universal/roles/install-kuma/tasks/kuma-binaries.yaml
@@ -7,50 +7,56 @@
     mode: "0755"
 
 - name: Copy kumactl
-  ansible.builtin.copy:
+  ansible.posix.synchronize:
     src: "{{ builddir }}/artifacts-linux-amd64/kumactl/kumactl"
     dest: "{{ kuma_bindir }}/kumactl"
-    mode: "0755"
+    archive: no
+    use_ssh_args: yes
   notify:
   - restart kuma services
 
 - name: Copy kuma-cp
-  ansible.builtin.copy:
+  ansible.posix.synchronize:
     src: "{{ builddir }}/artifacts-linux-amd64/kuma-cp/kuma-cp"
     dest: "{{ kuma_bindir }}/kuma-cp"
-    mode: "0755"
+    archive: no
+    use_ssh_args: yes
   notify:
   - restart kuma services
 
 - name: Copy kuma-dp
-  ansible.builtin.copy:
+  ansible.posix.synchronize:
     src: "{{ builddir }}/artifacts-linux-amd64/kuma-dp/kuma-dp"
     dest: "{{ kuma_bindir }}/kuma-dp"
-    mode: "0755"
+    archive: no
+    use_ssh_args: yes
   notify:
   - restart kuma services
 
 - name: Copy coredns
-  ansible.builtin.copy:
+  ansible.posix.synchronize:
     src: "{{ builddir }}/artifacts-linux-amd64/coredns/coredns"
     dest: "{{ kuma_bindir }}/coredns"
-    mode: "0755"
+    archive: no
+    use_ssh_args: yes
   notify:
   - restart kuma services
 
 - name: Copy test-server
-  ansible.builtin.copy:
+  ansible.posix.synchronize:
     src: "{{ builddir }}/artifacts-linux-amd64/test-server/test-server"
     dest: "{{ kuma_bindir }}/test-server"
-    mode: "0755"
+    archive: no
+    use_ssh_args: yes
   notify:
   - restart kuma services
 
 - name: Copy kuma-prometheus-sd
-  ansible.builtin.copy:
+  ansible.posix.synchronize:
     src: "{{ builddir }}/artifacts-linux-amd64/kuma-prometheus-sd/kuma-prometheus-sd"
     dest: "{{ kuma_bindir }}/kuma-prometheus-sd"
-    mode: "0755"
+    archive: no
+    use_ssh_args: yes
   notify:
   - restart kuma services
 


### PR DESCRIPTION
The ansible copy module is really slow, so switch to the rsync module,
which is faster but has a bit less control over file attributes.

Signed-off-by: James Peach <james.peach@konghq.com>