### PR TITLE
Install an echo service to the mesh.

### DIFF
--- a/ansible-universal/roles/all/tasks/main.yml
+++ b/ansible-universal/roles/all/tasks/main.yml
@@ -1,5 +1,15 @@
 ---
 
+# Ensure that all hosts are updated.
+- name: Upgrade all packages
+  dnf:
+    name: "*"
+    state: latest
+  when: ansible_os_family == "RedHat"
+
+# Configure the local hostname `control-plane` for all hosts in the control
+# plane group. This makes it easier for any other Kuma tooling to reach the
+# Kuma API server.
 - name: Add IPv4 address for control-plane hosts
   lineinfile:
     dest: /etc/hosts

--- a/ansible-universal/roles/control-plane/tasks/main.yml
+++ b/ansible-universal/roles/control-plane/tasks/main.yml
@@ -14,6 +14,20 @@
     state: directory
     mode: "0755"
 
+- name: Generate Kuma control plane certificate
+  become: yes
+  become_user: kuma
+  ansible.builtin.command:
+    creates: "{{ kuma_statedir }}/control-plane-cert.pem"
+    argv:
+    - "{{ kuma_bindir }}/kumactl"
+    - generate
+    - tls-certificate
+    - "--type=server"
+    - "--cp-hostname=control-plane"
+    - "--key-file={{ kuma_statedir }}/control-plane-key.pem"
+    - "--cert-file={{ kuma_statedir }}/control-plane-cert.pem"
+
 - name: Install kuma config file
   ansible.builtin.template:
     src: kuma.conf

--- a/ansible-universal/roles/control-plane/templates/kuma.conf
+++ b/ansible-universal/roles/control-plane/templates/kuma.conf
@@ -1,6 +1,8 @@
 # {{ ansible_managed }}.
 general:
   workDir: {{ kuma_statedir }}
+  tlsCertFile:  {{ kuma_statedir }}/control-plane-cert.pem
+  tlsKeyFile:  {{ kuma_statedir }}/control-plane-key.pem
 
 apiServer:
   readOnly: false
@@ -11,3 +13,7 @@ apiServer:
 
 dpServer:
   port: 5678
+  # Since DP authorization mechanisms tightly couple management
+  # of the control plane and the data plane, disable auth for now.
+  auth:
+    type: none

--- a/ansible-universal/roles/data-plane/handlers/main.yml
+++ b/ansible-universal/roles/data-plane/handlers/main.yml
@@ -1,14 +1,15 @@
 ---
 
-- name: restart kuma-dp service
+- name: restart {{ service_name}} dataplane
   listen: restart kuma services
   ansible.builtin.systemd:
-    name: kuma-dp
+    name: "{{ service_name }}-dataplane"
     state: restarted
 
-- name: reload kuma-dp service
+- name: reload {{ service_name}} dataplane
   ansible.builtin.systemd:
-    name: kuma-dp
+    name: "{{ service_name }}-dataplane"
     state: restarted
+    enabled: true
     daemon_reload: yes
 

--- a/ansible-universal/roles/data-plane/tasks/main.yml
+++ b/ansible-universal/roles/data-plane/tasks/main.yml
@@ -33,19 +33,19 @@
     mode: "0755"
 
 - name: Install kuma-dp sysconfig
-  notify: restart kuma-dp service
+  notify: restart {{ service_name }} dataplane
   ansible.builtin.template:
     src: kuma-dp.sysconfig
-    dest: /etc/sysconfig/kuma-dp
+    dest: /etc/sysconfig/{{ service_name }}-dataplane.conf
 
 - name: Install dataplane sysconfig
-  notify: restart kuma-dp service
+  notify: restart {{ service_name }} dataplane
   ansible.builtin.template:
     src: dataplane.conf
     dest: "{{ kuma_confdir }}/dataplanes/{{ service_name }}.conf"
 
-- name: Install kuma-dp service
-  notify: reload kuma-dp service
+- name: Install dataplane service for {{ service_name }}
+  notify: reload {{ service_name}} dataplane
   ansible.builtin.template:
     src: kuma-dp.service
-    dest: /etc/systemd/system/kuma-dp.service
+    dest: /etc/systemd/system/{{ service_name }}-dataplane.service

--- a/ansible-universal/roles/data-plane/templates/dataplane.conf
+++ b/ansible-universal/roles/data-plane/templates/dataplane.conf
@@ -1,8 +1,9 @@
 # {{ ansible_managed }}.
+# Dataplane configuration for {{ service_name }} service.
 
 type: Dataplane
 mesh: default
-name: {{ ansible_facts['nodename'] | replace('.', '-') }}
+name: {{ (service_name ~ '.' ~ ansible_facts['nodename']) | replace('.', '-') }}
 networking:
   address: 127.0.0.1
   inbound:

--- a/ansible-universal/roles/data-plane/templates/kuma-dp.service
+++ b/ansible-universal/roles/data-plane/templates/kuma-dp.service
@@ -1,25 +1,25 @@
 # {{ ansible_managed }}.
 
 [Unit]
-Description=Kuma Data Plane in Universal mode
+Description=Kuma Dataplane for {{ service_name }}
 After=network.target
+Requires={{ service_name }}
 Documentation=https://kuma.io
 
 [Service]
-EnvironmentFile=-/etc/sysconfig/kuma-cp
+EnvironmentFile=-/etc/sysconfig/{{ service_name }}-dataplane.conf
 
-ExecStartPre={{ kuma_bindir }}/kumactl generate dataplane-token \
-    --proxy-type dataplane \
-    --name "{{ ansible_facts['nodename'] | replace('.', '-') }}" \
-    > "{{ kuma_statedir }}/{{ ansible_facts['nodename'] | replace('.', '-') }}".dp
+# Force an image pull before kuma-dp tries to run it.
+ExecStartPre={{ kuma_bindir}}/envoy --version
+
+# Note that we assume no dataplane authorization.
 
 ExecStart={{ kuma_bindir }}/kuma-dp run \
     --proxy-type dataplane \
     --cp-address https://control-plane:5678 \
-    --dataplane-token-file "{{ kuma_statedir }}/{{ ansible_facts['nodename'] | replace('.', '-') }}".dp \
     --dataplane-file "{{ kuma_confdir }}/dataplanes/{{ service_name }}.conf" \
-    --config-dir "{{ kuma_statedir }}/kuma-dp/{{ service_name }}" \
-    --dns-server-config-dir "{{ kuma_statedir }}/kuma-dp/{{ service_name }}" \
+    --config-dir "{{ kuma_statedir }}/{{ service_name }}" \
+    --dns-server-config-dir "{{ kuma_statedir }}/{{ service_name }}" \
     --dns-coredns-path "{{ kuma_bindir }}/coredns" \
     --binary-path "{{ kuma_bindir }}/envoy"
 
@@ -32,6 +32,10 @@ StartLimitBurst=0
 User=kuma
 
 LimitNOFILE=1048576
+
+# Propagate the capability to bind to ports < 1024.
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+NoNewPrivileges=true
 
 [Install]
 WantedBy=multi-user.target

--- a/ansible-universal/roles/data-plane/templates/kuma-dp.sysconfig
+++ b/ansible-universal/roles/data-plane/templates/kuma-dp.sysconfig
@@ -1,2 +1,2 @@
 # {{ ansible_managed }}.
-# kuma-dp environment variables.
+# {{ service_name }}-dataplane.service environment variables.

--- a/ansible-universal/roles/echo-server/handlers/main.yml
+++ b/ansible-universal/roles/echo-server/handlers/main.yml
@@ -10,4 +10,5 @@
   ansible.builtin.systemd:
     name: echo-server
     state: restarted
+    enabled: true
     daemon_reload: yes

--- a/ansible-universal/roles/echo-server/tasks/main.yml
+++ b/ansible-universal/roles/echo-server/tasks/main.yml
@@ -10,11 +10,19 @@
   notify: restart echo-server service
   ansible.builtin.template:
     src: echo-server.sysconfig
-    dest: /etc/sysconfig/echo-server
+    dest: /etc/sysconfig/echo-server.conf
 
 - name: Install echo-server service
   notify: reload echo-server service
   ansible.builtin.template:
     src: echo-server.service
     dest: /etc/systemd/system/echo-server.service
+
+- name: Install echo-server dataplane
+  ansible.builtin.include_role:
+    name: data-plane
+  vars:
+    service_name: echo-server
+    service_port: "{{ 20000 + listen_port }}"
+    workload_port: "{{ listen_port }}"
 

--- a/ansible-universal/roles/echo-server/templates/echo-server.service
+++ b/ansible-universal/roles/echo-server/templates/echo-server.service
@@ -6,7 +6,7 @@ After=network.target
 Documentation=https://kuma.io
 
 [Service]
-EnvironmentFile=-/etc/sysconfig/echo-server
+EnvironmentFile=-/etc/sysconfig/echo-server.conf
 
 ExecStart={{ kuma_bindir }}/test-server echo --instance {{ ansible_facts['nodename'] }} --port {{ listen_port }}
 

--- a/ansible-universal/roles/echo-server/templates/echo-server.sysconfig
+++ b/ansible-universal/roles/echo-server/templates/echo-server.sysconfig
@@ -1,2 +1,2 @@
 # {{ ansible_managed }}.
-# kuma-cp environment variables.
+# echo-server.service environment variables.

--- a/ansible-universal/roles/install-kuma/tasks/envoy.yaml
+++ b/ansible-universal/roles/install-kuma/tasks/envoy.yaml
@@ -10,3 +10,7 @@
     src: envoy.sh
     dest: "{{ kuma_bindir }}/envoy"
     mode: "0755"
+
+- name: Pull envoy images
+  ansible.builtin.command:
+    cmd: "{{ kuma_bindir }}/envoy --version"

--- a/ansible-universal/roles/install-kuma/templates/envoy.sh
+++ b/ansible-universal/roles/install-kuma/templates/envoy.sh
@@ -7,5 +7,21 @@ set -o nounset
 readonly DOCKER=${DOCKER:-podman}
 readonly ENVOY=${ENVOY:-{{envoy.repository}}:{{envoy.version}}}
 
-exec $DOCKER run --network host $ENVOY "$@"
+readonly HERE=$(cd $(dirname $0) && pwd)
+readonly ENVOY_BIN="$HERE/.bin/envoy.{{envoy.version}}"
 
+# This is just atrocious. podman ignores `--user=root` which we need to be able
+# to read the envoy bootstrap, so avoid the whole mess of containerization by
+# copying the envoy binary out of the container. Surprisingly, the binary from
+# the Envoy Ubuntu-based image works fine on Fedora  ¯\_(ツ)_/¯
+if [ ! -x "$ENVOY_BIN" ]; then
+  readonly CONTAINERID="envoy-binary-source-$RANDOM"
+
+  mkdir -p $(dirname "$ENVOY_BIN")
+
+  "$DOCKER" run --detach --security-opt label=disable --name "$CONTAINERID" "$ENVOY" sleep 1d
+  "$DOCKER" cp "$CONTAINERID":/usr/local/bin/envoy "$ENVOY_BIN"
+  "$DOCKER" kill "$CONTAINERID"
+fi
+
+exec "$ENVOY_BIN" "$@"

--- a/ansible-universal/roles/install-kuma/vars/main.yml
+++ b/ansible-universal/roles/install-kuma/vars/main.yml
@@ -3,5 +3,5 @@
 builddir: /home/jpeach/upstream/konghq/kuma/build
 
 envoy:
-  repository: docker.io/envoyproxy/envoy-distroless
-  version: v1.20.0
+  repository: docker.io/envoyproxy/envoy
+  version: v1.18.4

--- a/ansible-universal/site.yml
+++ b/ansible-universal/site.yml
@@ -4,6 +4,8 @@
   roles:
   - role: all
     become: yes
+  - role: install-kuma
+    become: yes
 
 - hosts: controlplane
   roles:
@@ -19,8 +21,3 @@
   - role: echo-server
     become: yes
     listen_port: 8080
-  - role: data-plane
-    become: yes
-    service_name: echo
-    service_port: 20000
-    workload_port: 8080


### PR DESCRIPTION
* Refactor so that the roles you install is for the echo server, and
  that pulls in and configures it's dataplane configuration.
* Fix the Envoy script to work around container permission problems
  with a different flavor of hackery.
* Ensure all hosts have updated packages.
* Update the README to give some pointers to what this is all doing.

Signed-off-by: James Peach <james.peach@konghq.com>