### PR TITLE
Stop copying binaries multiple times.

### DIFF
--- a/ansible-universal/roles/install-kuma/tasks/main.yml
+++ b/ansible-universal/roles/install-kuma/tasks/main.yml
@@ -16,7 +16,7 @@
   import_tasks: kuma-binaries.yaml
 
 - name: Configure kumactl
-  import_tasks: kuma-binaries.yaml
+  import_tasks: kumactl.yaml
 
 - name: Install Envoy binaries
   import_tasks: envoy.yaml

--- a/ansible-universal/site.yml
+++ b/ansible-universal/site.yml
@@ -9,15 +9,11 @@
 
 - hosts: controlplane
   roles:
-  - role: install-kuma
-    become: yes
   - role: control-plane
     become: yes
 
 - hosts: echoserver
   roles:
-  - role: install-kuma
-    become: yes
   - role: echo-server
     become: yes
     listen_port: 8080


### PR DESCRIPTION
Stop copying Kuma binaries multiple times by only applying the
"install-kuma" role once to all hosts. Fix multiple task inclusion,
which had a similar effect.

Signed-off-by: James Peach <james.peach@konghq.com>