### PR TITLE
Add IPv4 dataplane addresses.

### DIFF
--- a/ansible-universal/roles/data-plane/templates/dataplane.conf
+++ b/ansible-universal/roles/data-plane/templates/dataplane.conf
@@ -5,7 +5,7 @@ type: Dataplane
 mesh: default
 name: {{ (service_name ~ '.' ~ ansible_facts['nodename']) | replace('.', '-') }}
 networking:
-  address: 127.0.0.1
+  address: {{ ansible_facts.default_ipv4.address }}
   inbound:
   - port: {{ service_port }}
     servicePort: {{ workload_port }}

--- a/ansible-universal/roles/gateway/templates/dataplane.conf
+++ b/ansible-universal/roles/gateway/templates/dataplane.conf
@@ -5,7 +5,7 @@ type: Dataplane
 mesh: default
 name: {{ (service_name ~ '.' ~ ansible_facts['nodename']) | replace('.', '-') }}
 networking:
-  address: 127.0.0.1
+  address: {{ ansible_facts.default_ipv4.address }}
   gateway:
     type: BUILTIN
     tags:


### PR DESCRIPTION
Use the default IPv4 address for each dataplane configuration.

Signed-off-by: James Peach <james.peach@konghq.com>